### PR TITLE
[ISSUE #5] PolarisLimiter.Limit() should return an error instead of printing the error internally

### DIFF
--- a/polaris_ratelimit_test.go
+++ b/polaris_ratelimit_test.go
@@ -3,13 +3,14 @@ package grpcpolaris
 import (
 	"context"
 	"errors"
+	"log"
+	"testing"
+
 	"github.com/polarismesh/polaris-go/api"
 	"github.com/polarismesh/polaris-go/pkg/clock"
 	"github.com/polarismesh/polaris-go/pkg/model"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
-	"log"
-	"testing"
 )
 
 // mockPolarisLimitAPI mock 北极星SDK Limit


### PR DESCRIPTION
fix issue #5 